### PR TITLE
Fix gitignore for labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@
 /vendor
 
 ### ignore the var folder, but allow to committ the translation labels
-!/var
 /var/*
 !/var/labels


### PR DESCRIPTION
The first gitignore statement ignores everything inside `/var/`, which made the two lines below useless.